### PR TITLE
Update TAF csproj - Cross platform and less hard coded

### DIFF
--- a/TweaksAndFixes/Directory.Build.props
+++ b/TweaksAndFixes/Directory.Build.props
@@ -14,6 +14,9 @@
         <UAD_PATH Condition="'$(UAD_PATH)' == '' AND Exists('$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))/.steam/steam/$(UAD_Relative)')">$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))/.steam/steam/$(UAD_Relative)</UAD_PATH>
         <UAD_PATH Condition="'$(UAD_PATH)' == '' AND Exists('$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))/.local/share/Steam/$(UAD_Relative)')">$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))/.local/share/Steam/$(UAD_Relative)</UAD_PATH>
     </PropertyGroup>
+    <PropertyGroup Condition="'$(UAD_PATH)' != '' AND !$(UAD_PATH.EndsWith('/')) AND !$(UAD_PATH.EndsWith('\')) ">
+        <UAD_PATH>$(UAD_PATH)/</UAD_PATH>
+    </PropertyGroup>
     <Target Name="ValidateGamePath" BeforeTargets="CoreCompile">
         <Message Text="Target UAD_PATH = '$(UAD_PATH)'" Importance="High" />
         <Error Condition="'$(UAD_PATH)' == '' OR !Exists('$(UAD_PATH)')" Text="UAD_PATH '$(UAD_PATH)' does not exist. Set the UAD_PATH environment variable to the Ultimate Admiral Dreadnoughts install folder." />

--- a/TweaksAndFixes/Directory.Build.props
+++ b/TweaksAndFixes/Directory.Build.props
@@ -17,7 +17,7 @@
     <Target Name="ValidateGamePath" BeforeTargets="CoreCompile">
         <Message Text="Target UAD_PATH = '$(UAD_PATH)'" Importance="High" />
         <Error Condition="'$(UAD_PATH)' == '' OR !Exists('$(UAD_PATH)')" Text="UAD_PATH '$(UAD_PATH)' does not exist. Set the UAD_PATH environment variable to the Ultimate Admiral Dreadnoughts install folder." />
-        <Error Condition="!Exists('$(UAD_PATH)/MelonLoader')" Text="Please install Melon Loader, see installation guide: https://github.com/DukeDagor/UADRealismDIP?tab=readme-ov-file#installation" />
+        <Error Condition="!Exists('$(UAD_PATH)/MelonLoader')" Text="Please install MelonLoader, see installation guide: https://github.com/DukeDagor/UADRealismDIP?tab=readme-ov-file#installation" />
         <Warning Condition="!Exists('$(UAD_PATH)/Mods/UnityExplorer.ML.IL2CPP.dll') OR !Exists('$(UAD_PATH)/UserLibs/UniverseLib.IL2CPP.dll')" Text="Recommend installing sinai UnityExplorer for MelonLoader, IL2CPP Release ML 0.6, available at: https://github.com/sinai-dev/UnityExplorer#melonloader" />
     </Target>
 </Project>

--- a/TweaksAndFixes/Directory.Build.props
+++ b/TweaksAndFixes/Directory.Build.props
@@ -1,0 +1,23 @@
+<Project>
+    <PropertyGroup>
+        <UAD_Relative>steamapps/common/Ultimate Admiral Dreadnoughts/</UAD_Relative>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+        <UAD_PATH Condition="'$(UAD_PATH)' == '' AND Exists('C:/Program Files (x86)/Steam/$(UAD_Relative)')">C:/Program Files (x86)/Steam/$(UAD_Relative)</UAD_PATH>
+        <UAD_PATH Condition="'$(UAD_PATH)' == '' AND Exists('D:/Games/Steam/$(UAD_Relative)')">D:/Games/Steam/$(UAD_Relative)</UAD_PATH>
+        <UAD_PATH Condition="'$(UAD_PATH)' == '' AND Exists('D:/SteamLibrary/$(UAD_Relative)')">D:/SteamLibrary/$(UAD_Relative)</UAD_PATH>
+        <UAD_PATH Condition="'$(UAD_PATH)' == '' AND Exists('G:/Games/Steam/$(UAD_Relative)')">G:/Games/Steam/$(UAD_Relative)</UAD_PATH>
+        <UAD_PATH Condition="'$(UAD_PATH)' == '' AND Exists('G:/SteamLibrary/$(UAD_Relative)')">G:/SteamLibrary/$(UAD_Relative)</UAD_PATH>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+        <UAD_PATH Condition="'$(UAD_PATH)' == '' AND Exists('$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))/Library/Application Support/Steam/$(UAD_Relative)')">$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))/Library/Application Support/Steam/$(UAD_Relative)</UAD_PATH>
+        <UAD_PATH Condition="'$(UAD_PATH)' == '' AND Exists('$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))/.steam/steam/$(UAD_Relative)')">$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))/.steam/steam/$(UAD_Relative)</UAD_PATH>
+        <UAD_PATH Condition="'$(UAD_PATH)' == '' AND Exists('$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))/.local/share/Steam/$(UAD_Relative)')">$([System.Environment]::GetFolderPath(SpecialFolder.UserProfile))/.local/share/Steam/$(UAD_Relative)</UAD_PATH>
+    </PropertyGroup>
+    <Target Name="ValidateGamePath" BeforeTargets="CoreCompile">
+        <Message Text="Target UAD_PATH = '$(UAD_PATH)'" Importance="High" />
+        <Error Condition="'$(UAD_PATH)' == '' OR !Exists('$(UAD_PATH)')" Text="UAD_PATH '$(UAD_PATH)' does not exist. Set the UAD_PATH environment variable to the Ultimate Admiral Dreadnoughts install folder." />
+        <Error Condition="!Exists('$(UAD_PATH)/MelonLoader')" Text="Please install Melon Loader, see installation guide: https://github.com/DukeDagor/UADRealismDIP?tab=readme-ov-file#installation" />
+        <Warning Condition="!Exists('$(UAD_PATH)/Mods/UnityExplorer.ML.IL2CPP.dll') OR !Exists('$(UAD_PATH)/UserLibs/UniverseLib.IL2CPP.dll')" Text="Recommend installing sinai UnityExplorer for MelonLoader, IL2CPP Release ML 0.6, available at: https://github.com/sinai-dev/UnityExplorer#melonloader" />
+    </Target>
+</Project>

--- a/TweaksAndFixes/TweaksAndFixes.csproj
+++ b/TweaksAndFixes/TweaksAndFixes.csproj
@@ -10,97 +10,119 @@
 
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>G:\Games\Steam\steamapps\common\Ultimate Admiral Dreadnoughts\MelonLoader\net6\0Harmony.dll</HintPath>
+      <HintPath>$(UAD_PATH)MelonLoader/net6/0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>G:\Games\Steam\steamapps\common\Ultimate Admiral Dreadnoughts\MelonLoader\Il2CppAssemblies\Assembly-CSharp.dll</HintPath>
+      <HintPath>$(UAD_PATH)MelonLoader/Il2CppAssemblies/Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>G:\Games\Steam\steamapps\common\Ultimate Admiral Dreadnoughts\MelonLoader\Il2CppAssemblies\Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath>$(UAD_PATH)MelonLoader/Il2CppAssemblies/Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="Il2CppInterop.Runtime">
-      <HintPath>G:\Games\Steam\steamapps\common\Ultimate Admiral Dreadnoughts\MelonLoader\net6\Il2CppInterop.Runtime.dll</HintPath>
+      <HintPath>$(UAD_PATH)MelonLoader/net6/Il2CppInterop.Runtime.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Il2CppMessagePack">
-      <HintPath>G:\Games\Steam\steamapps\common\Ultimate Admiral Dreadnoughts\MelonLoader\Il2CppAssemblies\Il2CppMessagePack.dll</HintPath>
+      <HintPath>$(UAD_PATH)MelonLoader/Il2CppAssemblies/Il2CppMessagePack.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Il2Cppmscorlib">
-      <HintPath>G:\Games\Steam\steamapps\common\Ultimate Admiral Dreadnoughts\MelonLoader\Il2CppAssemblies\Il2Cppmscorlib.dll</HintPath>
+      <HintPath>$(UAD_PATH)MelonLoader/Il2CppAssemblies/Il2Cppmscorlib.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Il2CppNewtonsoft.Json">
-      <HintPath>G:\Games\Steam\steamapps\common\Ultimate Admiral Dreadnoughts\MelonLoader\Il2CppAssemblies\Il2CppNewtonsoft.Json.dll</HintPath>
+      <HintPath>$(UAD_PATH)MelonLoader/Il2CppAssemblies/Il2CppNewtonsoft.Json.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Il2CppSystem">
-      <HintPath>G:\Games\Steam\steamapps\common\Ultimate Admiral Dreadnoughts\MelonLoader\Il2CppAssemblies\Il2CppSystem.dll</HintPath>
+      <HintPath>$(UAD_PATH)MelonLoader/Il2CppAssemblies/Il2CppSystem.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Il2CppSystem.Core">
-      <HintPath>G:\Games\Steam\steamapps\common\Ultimate Admiral Dreadnoughts\MelonLoader\Il2CppAssemblies\Il2CppSystem.Core.dll</HintPath>
+      <HintPath>$(UAD_PATH)MelonLoader/Il2CppAssemblies/Il2CppSystem.Core.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="MelonLoader">
-      <HintPath>G:\Games\Steam\steamapps\common\Ultimate Admiral Dreadnoughts\MelonLoader\net6\MelonLoader.dll</HintPath>
+      <HintPath>$(UAD_PATH)MelonLoader/net6/MelonLoader.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Unity.TextMeshPro">
-      <HintPath>G:\Games\Steam\steamapps\common\Ultimate Admiral Dreadnoughts\MelonLoader\Il2CppAssemblies\Unity.TextMeshPro.dll</HintPath>
+      <HintPath>$(UAD_PATH)MelonLoader/Il2CppAssemblies/Unity.TextMeshPro.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>G:\Games\Steam\steamapps\common\Ultimate Admiral Dreadnoughts\MelonLoader\Il2CppAssemblies\UnityEngine.dll</HintPath>
+      <HintPath>$(UAD_PATH)MelonLoader/Il2CppAssemblies/UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>G:\Games\Steam\steamapps\common\Ultimate Admiral Dreadnoughts\MelonLoader\Il2CppAssemblies\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(UAD_PATH)MelonLoader/Il2CppAssemblies/UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ImageConversionModule">
-      <HintPath>G:\Games\Steam\steamapps\common\Ultimate Admiral Dreadnoughts\MelonLoader\Il2CppAssemblies\UnityEngine.ImageConversionModule.dll</HintPath>
+      <HintPath>$(UAD_PATH)MelonLoader/Il2CppAssemblies/UnityEngine.ImageConversionModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>G:\Games\Steam\steamapps\common\Ultimate Admiral Dreadnoughts\MelonLoader\Il2CppAssemblies\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>$(UAD_PATH)MelonLoader/Il2CppAssemblies/UnityEngine.IMGUIModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.InputLegacyModule">
-      <HintPath>G:\Games\Steam\steamapps\common\Ultimate Admiral Dreadnoughts\MelonLoader\Il2CppAssemblies\UnityEngine.InputLegacyModule.dll</HintPath>
+      <HintPath>$(UAD_PATH)MelonLoader/Il2CppAssemblies/UnityEngine.InputLegacyModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.InputModule">
-      <HintPath>G:\Games\Steam\steamapps\common\Ultimate Admiral Dreadnoughts\MelonLoader\Il2CppAssemblies\UnityEngine.InputModule.dll</HintPath>
+      <HintPath>$(UAD_PATH)MelonLoader/Il2CppAssemblies/UnityEngine.InputModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.Physics2DModule">
-      <HintPath>G:\Games\Steam\steamapps\common\Ultimate Admiral Dreadnoughts\MelonLoader\Il2CppAssemblies\UnityEngine.Physics2DModule.dll</HintPath>
+      <HintPath>$(UAD_PATH)MelonLoader/Il2CppAssemblies/UnityEngine.Physics2DModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.PhysicsModule">
-      <HintPath>G:\Games\Steam\steamapps\common\Ultimate Admiral Dreadnoughts\MelonLoader\Il2CppAssemblies\UnityEngine.PhysicsModule.dll</HintPath>
+      <HintPath>$(UAD_PATH)MelonLoader/Il2CppAssemblies/UnityEngine.PhysicsModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">
-      <HintPath>G:\Games\Steam\steamapps\common\From The Depths\From_The_Depths_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
+      <HintPath>$(UAD_PATH)MelonLoader/Il2CppAssemblies/UnityEngine.TextRenderingModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>G:\Games\Steam\steamapps\common\Ultimate Admiral Dreadnoughts\MelonLoader\Il2CppAssemblies\UnityEngine.UI.dll</HintPath>
+      <HintPath>$(UAD_PATH)MelonLoader/Il2CppAssemblies/UnityEngine.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UIModule">
-      <HintPath>G:\Games\Steam\steamapps\common\Ultimate Admiral Dreadnoughts\MelonLoader\Il2CppAssemblies\UnityEngine.UIModule.dll</HintPath>
+      <HintPath>$(UAD_PATH)MelonLoader/Il2CppAssemblies/UnityEngine.UIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Properties\" />
+    <Folder Include="Properties/" />
   </ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="copy /Y &quot;$(TargetDir)TweaksAndFixes.dll&quot; &quot;G:\Games\Steam\steamapps\common\Ultimate Admiral Dreadnoughts\Mods\TweaksAndFixes.dll&quot;&#xD;&#xA;copy /Y &quot;$(TargetDir)TweaksAndFixes.dll&quot; &quot;$(ProjectDir)\TAF_Nightly\TweaksAndFixes.dll&quot;&#xD;&#xA;rd /Q /S &quot;G:\Games\Steam\steamapps\common\Ultimate Admiral Dreadnoughts\Mods\TAFData&quot;&#xD;&#xA;xcopy /Y /S &quot;$(ProjectDir)\Assets\*&quot; &quot;G:\Games\Steam\steamapps\common\Ultimate Admiral Dreadnoughts\Mods\&quot;" />
+  <Target Name="CopyAssets" AfterTargets="Build">
+    <Error Condition="'$(UAD_PATH)' == '' OR !Exists('$(UAD_PATH)')"
+           Text="UAD_PATH not set or invalid." />
+    
+    <ItemGroup>
+      <BuiltDll Include="$(TargetDir)TweaksAndFixes.dll" />
+      <AssetFiles Include="$(ProjectDir)Assets/**/*" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(BuiltDll)"
+          DestinationFiles="@(BuiltDll->'$(UAD_PATH)Mods/%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true" />
+
+    <Copy SourceFiles="@(BuiltDll)"
+          DestinationFiles="@(BuiltDll->'$(ProjectDir)TAF_Nightly/%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true" />
+
+
+    <RemoveDir Directories="$(UAD_PATH)Mods/TAFData"
+               Condition="Exists('$(UAD_PATH)Mods/TAFData')" />
+
+    <Copy SourceFiles="@(AssetFiles)"
+          DestinationFiles="@(AssetFiles->'$(UAD_PATH)Mods/%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true" />
   </Target>
 
 </Project>


### PR DESCRIPTION
No longer relies on hard coded paths to library references.
The new variables *should* be cross platform, but I don't have a linux/mac machine on hand to test with.
Included various default paths to avoid too many contributors needing to add an environment variable.

Uses MSBuild commands to move built files around instead of windows exclusive commands, again works on my machine but not tested on other OSes I don't have.